### PR TITLE
Add health check api point

### DIFF
--- a/mcmonarch/src/main.rs
+++ b/mcmonarch/src/main.rs
@@ -2,7 +2,7 @@ use color_eyre::{eyre, eyre::Result};
 use dotenv::dotenv;
 use futures::future::FutureExt;
 use futures::try_join;
-use std::{env, net::SocketAddrV4};
+use std::{env, net::TcpListener};
 
 const WEB_IP_ENVVAR: &str = "MCMONARCH_WEB_IP";
 const WEB_PORT_ENVVAR: &str = "MCMONARCH_WEB_PORT";
@@ -18,7 +18,7 @@ pub async fn main() -> Result<()> {
     let web_ip = env::var(WEB_IP_ENVVAR)?;
     let web_port = env::var(WEB_PORT_ENVVAR)?;
 
-    let web_addr = format!("{}:{}", web_ip, web_port).parse::<SocketAddrV4>()?;
+    let web_addr = TcpListener::bind(format!("{}:{}", web_ip, web_port))?;
 
     let verify_box = Box::new(|data| mcmonarch_bot::McmonarchBot::verify(data).boxed());
     let bot_fut = mcmonarch_bot::get_bot(&bot_token);

--- a/mcmonarch_web/Cargo.toml
+++ b/mcmonarch_web/Cargo.toml
@@ -11,7 +11,12 @@ log = "0.4.11"
 actix-web = "3"
 actix-files = "0.3.0"
 actix-http = "2.0"
+actix-rt = "1.1.1"
 futures = "0.3.5"
 color-eyre = "0.5.4"
 tokio = { version = "0.2", features = ["full"] }
 tokio-test = "0.2.1"
+
+[dev-dependencies]
+reqwest = "0.10.8"
+tokio = "0.2.22"

--- a/mcmonarch_web/tests/heartbeat.rs
+++ b/mcmonarch_web/tests/heartbeat.rs
@@ -1,0 +1,29 @@
+use futures::future::FutureExt;
+use mcmonarch_web;
+use std::net::TcpListener;
+
+#[actix_rt::test]
+async fn heartbeating() {
+    let bind_addr = spawn_app();
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(&format!("{}/heartbeat", &bind_addr))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert!(response.status().is_success());
+    assert_eq!(Some(0), response.content_length());
+}
+
+fn spawn_app() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind random port");
+    let port = listener.local_addr().unwrap().port();
+    let verify_cb = Box::new(|_| async { Ok(()) }.boxed());
+    let server = mcmonarch_web::run(listener, verify_cb).expect("Failed to launch test server");
+
+    let _ = tokio::spawn(server);
+
+    format!("http://127.0.0.1:{}", port)
+}


### PR DESCRIPTION
Add heartbeat api endpoint for verifying health of service.
Allows orchestrator to verify liveliness and kill malfunctioning
nodes
