### PR TITLE
Move docker_push.sh inline to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_success: |
 
 deploy:
   provider: script
-  script: bash docker_push.sh
+  script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; docker push alexlauni/monarchy-mcmonarch-face:latest 
   on:
     branch: main
 

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker push alexlauni/monarchy-mcmonarch-face:latest


### PR DESCRIPTION
Simple bash script can be written out directly in .travis.yml, we don't need an additional file for it.